### PR TITLE
Add duplicate callback support

### DIFF
--- a/async_dash/monkey_patch_callback.py
+++ b/async_dash/monkey_patch_callback.py
@@ -16,6 +16,7 @@ from dash._callback import (
     stringify_id,
     to_json,
 )
+from dash._utils import clean_property_name
 
 
 def register_callback(
@@ -99,7 +100,8 @@ def register_callback(
                     if not isinstance(vali, NoUpdate):
                         has_update = True
                         id_str = stringify_id(speci["id"])
-                        component_ids[id_str][speci["property"]] = vali
+                        prop = clean_property_name(speci["property"])
+                        component_ids[id_str][prop] = vali
 
             if not has_update:
                 raise PreventUpdate

--- a/async_dash/monkey_patch_callback_context.py
+++ b/async_dash/monkey_patch_callback_context.py
@@ -4,4 +4,5 @@ import quart
 
 def apply():
     flask.g = quart.g
+    flask.request = quart.request
     flask.has_request_context = quart.has_request_context

--- a/examples/duplicate_callbacks.py
+++ b/examples/duplicate_callbacks.py
@@ -1,0 +1,37 @@
+from async_dash import Dash
+from dash import html, dcc, Output, Input
+from quart import Quart
+
+import plotly.express as px
+import plotly.graph_objects as go
+
+server = Quart(__name__)
+app = Dash(
+    server=server,
+    prevent_initial_callbacks=True
+)
+
+app.layout = html.Div([
+    html.Button('Draw Graph', id='draw-2'),
+    html.Button('Reset Graph', id='reset-2'),
+    dcc.Graph(id='duplicate-output-graph')
+])
+
+@app.callback(
+    Output('duplicate-output-graph', 'figure', allow_duplicate=True),
+    Input('draw-2', 'n_clicks'),
+    prevent_initial_call=True
+)
+def draw_graph(n_clicks):
+    df = px.data.iris()
+    return px.scatter(df, x=df.columns[0], y=df.columns[1], color="species")
+
+@app.callback(
+    Output('duplicate-output-graph', 'figure'),
+    Input('reset-2', 'n_clicks'),
+)
+def reset_graph(input):
+    return go.Figure()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/examples/page_example/app.py
+++ b/examples/page_example/app.py
@@ -1,0 +1,27 @@
+from async_dash import Dash
+import dash
+from dash import html, dcc
+from quart import Quart
+
+server = Quart(__name__)
+
+app = Dash(__name__, server=server, use_pages=True)
+
+app.layout = html.Div(
+    [
+        html.H1("App Frame"),
+        html.Div(
+            [
+                html.Div(
+                    dcc.Link(f"{page['name']} - {page['path']}", href=page["path"])
+                )
+                for page in dash.page_registry.values()
+                if page["module"] != "pages.not_found_404"
+            ]
+        ),
+        dash.page_container,
+    ]
+)
+
+if __name__ == "__main__":
+    server.run()

--- a/examples/page_example/pages/page1.py
+++ b/examples/page_example/pages/page1.py
@@ -1,0 +1,3 @@
+import dash
+
+dash.register_page("home", layout="We're home!", path="/page1")

--- a/examples/page_example/pages/page2.py
+++ b/examples/page_example/pages/page2.py
@@ -1,0 +1,5 @@
+import dash
+
+dash.register_page(
+    "very_important", layout="Don't miss it!", path="/page2", order=0
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,8 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-dash = "^2.2.0"
-quart = "^0.19.4"
+dash = ">=2.9.0"
+quart = "^0.17.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-dash"
-version = "0.1.0a1"
+version = "0.2.0"
 description = "Async port of the official Plotly Dash library"
 authors = ["Snehil Vijay <snehilvj@outlook.com>"]
 license = "MIT"
@@ -36,7 +36,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = ">=3.7"
 dash = "^2.2.0"
-quart = "^0.16.3"
+quart = "^0.19.4"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"


### PR DESCRIPTION
Dash utilizes the `clean_property_name` utility to remove the hash appended to duplicate `component_property` names via callbacks. Currently, repo does not support cleaning and thus duplicate callbacks are not registered correctly.

MWE 
```
from async_dash import Dash
from dash import html, dcc, Output, Input
from quart import Quart

import plotly.express as px
import plotly.graph_objects as go

server = Quart(__name__)
app = Dash(
    server=server,
    prevent_initial_callbacks=True
)

app.layout = html.Div([
    html.Button('Draw Graph', id='draw-2'),
    html.Button('Reset Graph', id='reset-2'),
    dcc.Graph(id='duplicate-output-graph')
])

@app.callback(
    Output('duplicate-output-graph', 'figure', allow_duplicate=True),
    Input('draw-2', 'n_clicks'),
    prevent_initial_call=True
)
def draw_graph(n_clicks):
    df = px.data.iris()
    return px.scatter(df, x=df.columns[0], y=df.columns[1], color="species")

@app.callback(
    Output('duplicate-output-graph', 'figure'),
    Input('reset-2', 'n_clicks'),
)
def reset_graph(input):
    return go.Figure()

if __name__ == '__main__':
    app.run(debug=True)
```